### PR TITLE
Added a maven property to always encode files as UTF-8 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
 		<url>https://github.com/Zenika/ceci-n-est-pas-un-bus-de-messages/issues</url>
 	</issueManagement>
 
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
To make builds not platform dependent =) (removes a warning message at build time)